### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,27 @@
+name: Security audit
+
+on:
+  push:
+    paths:
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+
+jobs:
+  audit:
+    name: Security audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install cargo-audit
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-audit
+          version: latest
+          use-tool-cache: true
+
+      - name: Audit
+        uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,58 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CLIPPY_PARAMS: -D warnings
+
+jobs:
+  rustfmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt
+
+      - name: Run rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check --verbose
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@master
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: clippy
+
+      - name: Run clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all --all-features --all-targets -- ${{ env.CLIPPY_PARAMS }}
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  test:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - name: Publish
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --verbose --all-features --token ${{ secrets.CARGO_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macOS-latest
+        toolchain:
+          - nightly
+        cargo_flags:
+          - "--no-default-features"
+          - "--all-features"
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all ${{ matrix.cargo_flags }}
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all ${{ matrix.cargo_flags }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/anixe/diff-assert"
 
+
 [badges]
 maintenance = { status = "actively-developed" }
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 [![Crates.io](https://img.shields.io/crates/v/diff-assert.svg)](https://crates.io/crates/diff-assert)
 [![Docs.rs](https://docs.rs/diff-assert/badge.svg)](https://docs.rs/diff-assert)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/rust-lang/docs.rs/master/LICENSE)
+![Lint](https://github.com/anixe/diff-assert/workflows/Lint/badge.svg)
+![Test](https://github.com/anixe/diff-assert/workflows/Test/badge.svg)
+![Audit](https://github.com/anixe/diff-assert/workflows/Security%20audit/badge.svg)
 ![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)
 
 ## About this crate
@@ -54,7 +57,7 @@ cp .hooks/* .git/hooks/
 All issues and pull requests are welcomed :)
 
 Recommended handy tools:
-* `cargo readme` - to generate README.md,
+* `cargo readme` - to generate README.md, use `scripts/readme.sh`
 * `cargo fmt` - to reformat workspace,
 * `cargo edit` - to add/remove dependencies,
 * `cargo clippy` - to maintain code quality,

--- a/README.tpl
+++ b/README.tpl
@@ -2,6 +2,9 @@
 [![Crates.io](https://img.shields.io/crates/v/diff-assert.svg)](https://crates.io/crates/diff-assert)
 [![Docs.rs](https://docs.rs/diff-assert/badge.svg)](https://docs.rs/diff-assert)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/rust-lang/docs.rs/master/LICENSE)
+![Lint](https://github.com/anixe/diff-assert/workflows/Lint/badge.svg)
+![Test](https://github.com/anixe/diff-assert/workflows/Test/badge.svg)
+![Audit](https://github.com/anixe/diff-assert/workflows/Security%20audit/badge.svg)
 {{badges}}
 
 {{readme}}
@@ -15,7 +18,7 @@ cp .hooks/* .git/hooks/
 All issues and pull requests are welcomed :)
 
 Recommended handy tools:
-* `cargo readme` - to generate README.md,
+* `cargo readme` - to generate README.md, use `scripts/readme.sh`
 * `cargo fmt` - to reformat workspace,
 * `cargo edit` - to add/remove dependencies,
 * `cargo clippy` - to maintain code quality,

--- a/diff-utils/README.md
+++ b/diff-utils/README.md
@@ -2,6 +2,9 @@
 [![Crates.io](https://img.shields.io/crates/v/diff-utils.svg)](https://crates.io/crates/diff-utils)
 [![Docs.rs](https://docs.rs/diff-utils/badge.svg)](https://docs.rs/diff-utils)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/rust-lang/docs.rs/master/LICENSE)
+![Lint](https://github.com/anixe/diff-assert/workflows/Lint/badge.svg)
+![Test](https://github.com/anixe/diff-assert/workflows/Test/badge.svg)
+![Audit](https://github.com/anixe/diff-assert/workflows/Security%20audit/badge.svg)
 ![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)
 
 ## About this crate
@@ -42,7 +45,7 @@ cp .hooks/* .git/hooks/
 All issues and pull requests are welcomed :)
 
 Recommended handy tools:
-* `cargo readme` - to generate README.md,
+* `cargo readme` - to generate README.md, use `scripts/readme.sh`
 * `cargo fmt` - to reformat workspace,
 * `cargo edit` - to add/remove dependencies,
 * `cargo clippy` - to maintain code quality,

--- a/diff-utils/README.tpl
+++ b/diff-utils/README.tpl
@@ -2,6 +2,9 @@
 [![Crates.io](https://img.shields.io/crates/v/diff-utils.svg)](https://crates.io/crates/diff-utils)
 [![Docs.rs](https://docs.rs/diff-utils/badge.svg)](https://docs.rs/diff-utils)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/rust-lang/docs.rs/master/LICENSE)
+![Lint](https://github.com/anixe/diff-assert/workflows/Lint/badge.svg)
+![Test](https://github.com/anixe/diff-assert/workflows/Test/badge.svg)
+![Audit](https://github.com/anixe/diff-assert/workflows/Security%20audit/badge.svg)
 {{badges}}
 
 {{readme}}
@@ -15,7 +18,7 @@ cp .hooks/* .git/hooks/
 All issues and pull requests are welcomed :)
 
 Recommended handy tools:
-* `cargo readme` - to generate README.md,
+* `cargo readme` - to generate README.md, use `scripts/readme.sh`
 * `cargo fmt` - to reformat workspace,
 * `cargo edit` - to add/remove dependencies,
 * `cargo clippy` - to maintain code quality,

--- a/diff-utils/src/context.rs
+++ b/diff-utils/src/context.rs
@@ -16,11 +16,7 @@ pub(crate) struct Context<'a> {
 
 impl<'a> Context<'a> {
     pub fn create_hunk(&mut self, removed: usize, inserted: usize) -> Option<Hunk<'a>> {
-        let mut start = if let Some(start) = self.start {
-            start
-        } else {
-            return None;
-        };
+        let mut start = self.start?;
         if start == 0 {
             start = 1;
         }

--- a/scripts/readme.sh
+++ b/scripts/readme.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 cargo readme > README.md
 cd diff-utils/


### PR DESCRIPTION
This Pull Request creates a CI pipeline with lints, audit, and tests.

To create a new release of diff-assert on crates.io we need to:
* Login on `crates.io` with your Github account,
* Go to https://crates.io/me and create new deploy token,
* Go to Settings/Secrets and add a new secret called `CARGO_TOKEN` with the generated token.

Then every time we publish new `git tag`, it will automatically call `cargo publish` :) 

TODO in the future:
* [ ] run cargo readme before each release,
* [ ] create new release automatically on Github,
* [ ] find a nice way to generate a changelog or use a good changelog template.